### PR TITLE
Fix slow startup by restricting IMAP search to Amazon mail

### DIFF
--- a/custom_components/amazon_order_status/coordinator.py
+++ b/custom_components/amazon_order_status/coordinator.py
@@ -285,8 +285,13 @@ class AmazonOrdersCoordinator(DataUpdateCoordinator):
         # using the UTC date can ask for "future" emails and return 0. Use one day
         # earlier so we always fetch recent emails; we filter by since_utc in Python.
         since_date_imap = _imap_date_str(since_utc - timedelta(days=1))
-        # No charset for date-only criterion; some servers reject CHARSET with SINCE
-        typ, data = mail.search(None, f'(SINCE "{since_date_imap}")')
+        # Restrict the search to Amazon emails only. Searching all mail in folders like
+        # Gmail All Mail can touch hundreds of unrelated recent messages and block HA
+        # startup while every body is fetched.
+        # FROM "amazon.com" is broad enough to include the common order/tracking
+        # senders (auto-confirm@amazon.com, shipment-tracking@amazon.com, no-reply@amazon.com).
+        # No charset for date-only criterion; some servers reject CHARSET with SINCE.
+        typ, data = mail.search(None, f'(SINCE "{since_date_imap}" FROM "amazon.com")')
 
         if typ != "OK":
             _LOGGER.error("IMAP search failed")


### PR DESCRIPTION
## Summary
- restrict the IMAP `SEARCH` query to Amazon mail instead of scanning every recent message in the selected folder
- keep the existing `SINCE` window and Python-side timestamp filtering intact
- reduce startup stalls for users who point the integration at broad folders like Gmail `All Mail`

## Why
When the integration is configured to read from a large folder such as Gmail `All Mail`, the current search:

```python
mail.search(None, f'(SINCE "{since_date_imap}")')
```

returns all recent messages, including hundreds of unrelated emails. The coordinator then fetches each body to decide whether it belongs to Amazon. On a real Home Assistant deployment this caused setup/refresh to become very slow and effectively blocked startup.

## Change
This PR narrows the IMAP search to Amazon mail:

```python
mail.search(None, f'(SINCE "{since_date_imap}" FROM "amazon.com")')
```

That still allows the coordinator to find common Amazon order/tracking senders while avoiding expensive fetches for unrelated mail.

## Validation
Verified on a live Home Assistant installation with the integration configured against Gmail `All Mail`:
- before the change, startup slowed badly while scanning unrelated mail
- after the change, Home Assistant restarted quickly
- the integration successfully detected an existing Amazon order and updated the generated sensors correctly

If you prefer, I can follow up with tests or make the sender filter configurable.